### PR TITLE
Add Import/Export wanted vehicles to radar and map

### DIFF
--- a/CollectiblesOnRadar.sln
+++ b/CollectiblesOnRadar.sln
@@ -1,18 +1,20 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
+# Visual Studio Version 18
+VisualStudioVersion = 18.6.11822.322 stable
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CollectiblesOnRadar", "CollectiblesOnRadar.vcxproj", "{B212DDA4-2A8E-45B2-914D-7BEEB31D06B1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Release|Win32 = Release|Win32
 		Debug|Win32 = Debug|Win32
+		Release|Win32 = Release|Win32
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{B212DDA4-2A8E-45B2-914D-7BEEB31D06B1}.Release|Win32.ActiveCfg = Release|Win32
-		{B212DDA4-2A8E-45B2-914D-7BEEB31D06B1}.Release|Win32.Build.0 = Release|Win32
 		{B212DDA4-2A8E-45B2-914D-7BEEB31D06B1}.Debug|Win32.ActiveCfg = Debug|Win32
 		{B212DDA4-2A8E-45B2-914D-7BEEB31D06B1}.Debug|Win32.Build.0 = Debug|Win32
+		{B212DDA4-2A8E-45B2-914D-7BEEB31D06B1}.Release|Win32.ActiveCfg = Release|Win32
+		{B212DDA4-2A8E-45B2-914D-7BEEB31D06B1}.Release|Win32.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/CollectiblesOnRadar.sln
+++ b/CollectiblesOnRadar.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.6.11822.322 stable
+VisualStudioVersion = 18.6.11822.322
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CollectiblesOnRadar", "CollectiblesOnRadar.vcxproj", "{B212DDA4-2A8E-45B2-914D-7BEEB31D06B1}"
 EndProject
@@ -18,5 +18,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {4484C5B3-D4EB-4553-B70E-F23511DCA981}
 	EndGlobalSection
 EndGlobal

--- a/CollectiblesOnRadar.vcxproj
+++ b/CollectiblesOnRadar.vcxproj
@@ -21,13 +21,13 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -58,7 +58,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_CRT_NON_CONFORMING_SWPRINTFS;_USE_MATH_DEFINES;_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;NDEBUG;GTASA;PLUGIN_SGV_10US;RW;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>src;$(PLUGIN_SDK_DIR)\shared;$(PLUGIN_SDK_DIR)\shared\game;$(PLUGIN_SDK_DIR)\plugin_SA;$(PLUGIN_SDK_DIR)\plugin_SA\game_SA;$(PLUGIN_SDK_DIR)\plugin_SA\game_SA\rw;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>src;$(PLUGIN_SDK_DIR)\shared;$(PLUGIN_SDK_DIR)\shared\game;$(PLUGIN_SDK_DIR)\plugin_SA;$(PLUGIN_SDK_DIR)\plugin_SA\game_SA;$(PLUGIN_SDK_DIR)\plugin_SA\game_SA\rw;$(PLUGIN_SDK_DIR)\plugin_SA\game_SA\enums;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>None</DebugInformationFormat>
       <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -86,7 +86,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_CRT_NON_CONFORMING_SWPRINTFS;_USE_MATH_DEFINES;_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;DEBUG;GTASA;PLUGIN_SGV_10US;RW;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>src;$(PLUGIN_SDK_DIR)\shared;$(PLUGIN_SDK_DIR)\shared\game;$(PLUGIN_SDK_DIR)\plugin_SA;$(PLUGIN_SDK_DIR)\plugin_SA\game_SA;$(PLUGIN_SDK_DIR)\plugin_SA\game_SA\rw;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>src;$(PLUGIN_SDK_DIR)\shared;$(PLUGIN_SDK_DIR)\shared\game;$(PLUGIN_SDK_DIR)\plugin_SA;$(PLUGIN_SDK_DIR)\plugin_SA\game_SA;$(PLUGIN_SDK_DIR)\plugin_SA\game_SA\rw;$(PLUGIN_SDK_DIR)\plugin_SA\game_SA\enums;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <Optimization>Disabled</Optimization>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -106,9 +106,11 @@
   <ItemGroup>
     <ClCompile Include="src\Settings.cpp" />
     <ClCompile Include="src\CollectiblesOnRadar.cpp" />
+    <ClCompile Include="src\ExportVehicles.cpp" />
     <ClCompile Include="src\Util.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="src\ExportVehicles.h" />
     <ClInclude Include="src\IniParser.h" />
     <ClInclude Include="src\IniReader.h" />
     <ClInclude Include="src\Settings.h" />

--- a/CollectiblesOnRadar.vcxproj
+++ b/CollectiblesOnRadar.vcxproj
@@ -78,7 +78,8 @@
       <ImportLibrary>output\asi\CollectiblesOnRadar.SA.lib</ImportLibrary>
     </Link>
     <PostBuildEvent>
-      <Command>copy /y "$(TargetPath)" "$(GTA_SA_DIR)\scripts\CollectiblesOnRadar.SA.asi"</Command>
+      <Command>
+      </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -100,7 +101,8 @@
       <ImportLibrary>output\asi\CollectiblesOnRadar.SA.lib</ImportLibrary>
     </Link>
     <PostBuildEvent>
-      <Command>copy /y "$(TargetPath)" "$(GTA_SA_DIR)\scripts\CollectiblesOnRadar.SA.asi"</Command>
+      <Command>
+      </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -7,4 +7,5 @@ This ASI plugin shows GTA San Andreas' collectibles on radar.
 
 - Shows tags ![tag](https://user-images.githubusercontent.com/81055036/112774885-6e0b2500-9011-11eb-98f2-620dc4b794cb.gif), snapshots ![snapshot](https://user-images.githubusercontent.com/81055036/112774887-6ea3bb80-9011-11eb-8dee-af5b75e5918f.gif), horseshoes ![horseshoe](https://user-images.githubusercontent.com/81055036/112774888-6ea3bb80-9011-11eb-9b22-6cf0619ef18e.gif), oysters ![oyster](https://user-images.githubusercontent.com/81055036/112774889-6ea3bb80-9011-11eb-9755-2c1e0db614d5.gif) and unique stunt jumps ![usj](https://user-images.githubusercontent.com/81055036/112774890-6f3c5200-9011-11eb-87a3-c5e5d7981cf7.gif)
 - Nearest collectible of each type always on the radar, even if outside radar's range
+- Optionally shows the Exports and Imports (Easter Basin docks) wanted vehicles: spawn locations of the cars still required by the active list on the map, plus a vehicle icon on the radar for matching vehicles near the player (see the `[EXPORT]` section in the INI)
 - Uses [DK22Pac's plugin-sdk](https://github.com/DK22Pac/plugin-sdk)

--- a/resources/CollectiblesOnRadar.SA.ini
+++ b/resources/CollectiblesOnRadar.SA.ini
@@ -23,3 +23,7 @@ color_armour=#FFFFFFA0
 color_weapon=#303030A0
 enabled_on_startup=true
 draw_dropped_weapons=false
+[EXPORT]
+show_export_vehicles=true
+sprite_id=55
+sprite_size=12

--- a/resources/CollectiblesOnRadar.SA.ini
+++ b/resources/CollectiblesOnRadar.SA.ini
@@ -27,3 +27,5 @@ draw_dropped_weapons=false
 show_export_vehicles=true
 sprite_id=55
 sprite_size=12
+; blue arrow above iconed traffic vehicles
+show_arrows=true

--- a/src/CollectiblesOnRadar.cpp
+++ b/src/CollectiblesOnRadar.cpp
@@ -6,6 +6,7 @@
 #include "CMenuManager.h" // FrontEndMenuManager.drawRadarOrMap
 #include "CPickups.h"
 #include "CRadar.h"
+#include "CTheScripts.h" // CTheScripts::IsPlayerOnAMission
 #include "CTimer.h" // CTimer::m_snTimeInMilliseconds
 
 #include "Util.h"
@@ -52,6 +53,12 @@ public:
         {
             CPlayerPed* playa = FindPlayerPed();
             if (!s_modEnabled || !playa || !Settings::s_drawExportVehicles)
+            {
+                return;
+            }
+
+            // the export script empties the wanted list during missions anyway
+            if (CTheScripts::IsPlayerOnAMission())
             {
                 return;
             }

--- a/src/CollectiblesOnRadar.cpp
+++ b/src/CollectiblesOnRadar.cpp
@@ -10,6 +10,11 @@
 #include "Settings.h"
 #include "ExportVehicles.h"
 
+// the same hook points as plugin's drawBlipsEvent, but with PRIORITY_BEFORE -
+// whatever is drawn here ends up above the radar ring, below every game blip
+static plugin::CdeclEvent<plugin::AddressList<0x58AA2D, plugin::H_JUMP, 0x575B44, plugin::H_CALL>,
+    plugin::PRIORITY_BEFORE, plugin::ArgPickNone, void()> drawBeforeBlipsEvent;
+
 class CollectiblesOnRadar
 {
 private:
@@ -41,9 +46,7 @@ public:
             }
         };
 
-        // fires after the gang overlay, before the game's own blips - so the
-        // export icons end up underneath the player marker and the waypoint
-        plugin::Events::drawRadarOverlayEvent += []
+        drawBeforeBlipsEvent += []
         {
             CPlayerPed* playa = FindPlayerPed();
             if (!s_modEnabled || !playa || !Settings::s_drawExportVehicles)

--- a/src/CollectiblesOnRadar.cpp
+++ b/src/CollectiblesOnRadar.cpp
@@ -1,5 +1,6 @@
 #include "plugin.h"
 #include "common.h"
+#include "C3dMarkers.h" // arrows above traffic vehicles
 #include "CCamera.h" // TheCamera
 #include "CHud.h" // CHud::SetHelpMessage
 #include "CMenuManager.h" // FrontEndMenuManager.drawRadarOrMap
@@ -548,6 +549,7 @@ private:
                 {
                     CRadar::TransformRadarPointToScreenSpace(screenSpace, radarSpace);
                     drawExportIcon(screenSpace.x, screenSpace.y, false);
+                    drawVehicleArrow(sticky, i);
                     stickyVehicleRef[i] = CPools::ms_pVehiclePool->GetRef(sticky);
                     continue;
                 }
@@ -560,10 +562,34 @@ private:
                 {
                     CRadar::TransformRadarPointToScreenSpace(screenSpace, radarSpace);
                     drawExportIcon(screenSpace.x, screenSpace.y, false);
+                    drawVehicleArrow(nearestVehicle[i], i);
                     stickyVehicleRef[i] = CPools::ms_pVehiclePool->GetRef(nearestVehicle[i]);
                 }
             }
         }
+    }
+
+    // a blue arrow above an iconed traffic vehicle, to tell it apart in dense
+    // traffic; parked spawns get none - their fixed locations are easy to spot
+    static void drawVehicleArrow(CVehicle* vehicle, int spawnIndex)
+    {
+        if (!Settings::s_drawExportArrows || vehicle->m_nCreatedBy != RANDOM_VEHICLE)
+        {
+            return;
+        }
+
+        if (vehicle->bHasBeenOwnedByPlayer)
+        {
+            return; // the player has already driven it - no need to point at it
+        }
+
+        const float bob = 0.25f * std::sin(CTimer::m_snTimeInMilliseconds * 0.006f);
+
+        CVector posn = vehicle->GetPosition();
+        posn.z += vehicle->GetColModel()->m_boundBox.m_vecMax.z + 1.5f + bob;
+
+        C3dMarkers::PlaceMarkerSet(0x45585000 + spawnIndex, MARKER3D_ARROW, posn, 1.5f,
+            0, 128, 255, 200, 1024, 0.2f, 0);
     }
 
     static bool isIconCandidate(CVehicle* vehicle, short playaModel)

--- a/src/CollectiblesOnRadar.cpp
+++ b/src/CollectiblesOnRadar.cpp
@@ -617,9 +617,10 @@ private:
             return false; // spawn marker is already drawn there
         }
 
-        // traffic behind the camera despawns quickly, so its icons only confuse
+        // distant traffic behind the camera despawns quickly, so its icons only
+        // confuse; nearby vehicles stay in memory, so they keep theirs
         const CVector2D toVehicle((vehiclePos - TheCamera.GetPosition()).To2D());
-        if (TheCamera.GetForward().To2D().Dot(toVehicle) < 0.f)
+        if (TheCamera.GetForward().To2D().Dot(toVehicle) < 0.f && toVehicle.Magnitude() > 50.f)
         {
             return false;
         }

--- a/src/CollectiblesOnRadar.cpp
+++ b/src/CollectiblesOnRadar.cpp
@@ -593,7 +593,7 @@ private:
         const float bob = 0.25f * std::sin(CTimer::m_snTimeInMilliseconds * 0.006f);
 
         CVector posn = vehicle->GetPosition();
-        posn.z += vehicle->GetColModel()->m_boundBox.m_vecMax.z + 1.5f + bob;
+        posn.z += vehicle->GetColModel()->m_boundBox.m_vecMax.z + 2.5f + bob;
 
         C3dMarkers::PlaceMarkerSet(0x45585000 + spawnIndex, MARKER3D_ARROW, posn, 1.5f,
             0, 128, 255, 200, 1024, 0.2f, 0);

--- a/src/CollectiblesOnRadar.cpp
+++ b/src/CollectiblesOnRadar.cpp
@@ -91,9 +91,9 @@ private:
 
             const CVector& tagPos = Util::s_tagList[i].tag->pos;
 
-            CRadar::TransformRealWorldPointToRadarSpace(radarSpace, CVector2D(tagPos));
+            CRadar::TransformRealWorldPointToRadarSpace(radarSpace, tagPos.To2D());
             const float mag = CRadar::LimitRadarPoint(radarSpace); // returns distance
-            const float distance = DistanceBetweenPoints(CVector2D(playaPos), CVector2D(tagPos));
+            const float distance = CVector2D::Distance(playaPos.To2D(), tagPos.To2D());
             if (mag <= 1.f) // (distance < CRadar::m_radarRange)
             {
                 CRadar::TransformRadarPointToScreenSpace(screenSpace, radarSpace);
@@ -137,7 +137,7 @@ private:
 
             const CVector& tagPos = Util::s_tagList[indexTag].tag->pos;
 
-            CRadar::TransformRealWorldPointToRadarSpace(radarSpace, CVector2D(tagPos));
+            CRadar::TransformRealWorldPointToRadarSpace(radarSpace, tagPos.To2D());
             CRadar::LimitRadarPoint(radarSpace);
             CRadar::TransformRadarPointToScreenSpace(screenSpace, radarSpace);
 
@@ -192,9 +192,9 @@ private:
                     continue;
                 }
 
-                CRadar::TransformRealWorldPointToRadarSpace(radarSpace, CVector2D(pickupPos));
+                CRadar::TransformRealWorldPointToRadarSpace(radarSpace, pickupPos.To2D());
                 const float mag = CRadar::LimitRadarPoint(radarSpace); // returns distance
-                const float distance = DistanceBetweenPoints(CVector2D(playaPos), CVector2D(pickupPos));
+                const float distance = CVector2D::Distance(playaPos.To2D(), pickupPos.To2D());
                 if (mag <= 1.f) // (distance < CRadar::m_radarRange)
                 {
                     CRadar::TransformRadarPointToScreenSpace(screenSpace, radarSpace);
@@ -275,7 +275,7 @@ private:
         {
             const CVector pickupPos(CPickups::aPickUps[indexOyster].m_vecPos.Uncompressed());
 
-            CRadar::TransformRealWorldPointToRadarSpace(radarSpace, CVector2D(pickupPos));
+            CRadar::TransformRealWorldPointToRadarSpace(radarSpace, pickupPos.To2D());
             CRadar::LimitRadarPoint(radarSpace);
             CRadar::TransformRadarPointToScreenSpace(screenSpace, radarSpace);
 
@@ -294,7 +294,7 @@ private:
         {
             const CVector pickupPos(CPickups::aPickUps[indexHorse].m_vecPos.Uncompressed());
 
-            CRadar::TransformRealWorldPointToRadarSpace(radarSpace, CVector2D(pickupPos));
+            CRadar::TransformRealWorldPointToRadarSpace(radarSpace, pickupPos.To2D());
             CRadar::LimitRadarPoint(radarSpace);
             CRadar::TransformRadarPointToScreenSpace(screenSpace, radarSpace);
 
@@ -313,7 +313,7 @@ private:
         {
             const CVector pickupPos(CPickups::aPickUps[indexSnap].m_vecPos.Uncompressed());
 
-            CRadar::TransformRealWorldPointToRadarSpace(radarSpace, CVector2D(pickupPos));
+            CRadar::TransformRealWorldPointToRadarSpace(radarSpace, pickupPos.To2D());
             CRadar::LimitRadarPoint(radarSpace);
             CRadar::TransformRadarPointToScreenSpace(screenSpace, radarSpace);
 
@@ -353,9 +353,9 @@ private:
                     (usj.start1.y + usj.start2.y) / 2.f,
                     usj.start1.z);
 
-                CRadar::TransformRealWorldPointToRadarSpace(radarSpace, CVector2D(usjPos));
+                CRadar::TransformRealWorldPointToRadarSpace(radarSpace, usjPos.To2D());
                 const float mag = CRadar::LimitRadarPoint(radarSpace); // returns distance
-                const float distance = DistanceBetweenPoints(CVector2D(playaPos), CVector2D(usjPos));
+                const float distance = CVector2D::Distance(playaPos.To2D(), usjPos.To2D());
                 if (mag <= 1.f) // (distance < CRadar::m_radarRange)
                 {
                     CRadar::TransformRadarPointToScreenSpace(screenSpace, radarSpace);
@@ -400,7 +400,7 @@ private:
                 (usj.start1.y + usj.start2.y) / 2.f,
                 usj.start1.z);
 
-            CRadar::TransformRealWorldPointToRadarSpace(radarSpace, CVector2D(usjPos));
+            CRadar::TransformRealWorldPointToRadarSpace(radarSpace, usjPos.To2D());
             CRadar::LimitRadarPoint(radarSpace);
             CRadar::TransformRadarPointToScreenSpace(screenSpace, radarSpace);
 
@@ -438,7 +438,7 @@ private:
 
             const CVector& tagPos = Util::s_tagList[i].tag->pos;
 
-            CRadar::TransformRealWorldPointToRadarSpace(radarSpace, CVector2D(tagPos));
+            CRadar::TransformRealWorldPointToRadarSpace(radarSpace, tagPos.To2D());
             //CRadar::LimitRadarPoint(radarSpace);
             CRadar::TransformRadarPointToScreenSpace(screenSpace, radarSpace);
 
@@ -483,7 +483,7 @@ private:
                 if (pickupPos.z >= 960.f)
                     continue;
 
-                CRadar::TransformRealWorldPointToRadarSpace(radarSpace, CVector2D(pickupPos));
+                CRadar::TransformRealWorldPointToRadarSpace(radarSpace, pickupPos.To2D());
                 //CRadar::LimitRadarPoint(radarSpace);
                 CRadar::TransformRadarPointToScreenSpace(screenSpace, radarSpace);
 
@@ -545,7 +545,7 @@ private:
                     (usj.start1.y + usj.start2.y) / 2.f,
                     usj.start1.z);
 
-                CRadar::TransformRealWorldPointToRadarSpace(radarSpace, CVector2D(usjPos));
+                CRadar::TransformRealWorldPointToRadarSpace(radarSpace, usjPos.To2D());
                 //CRadar::LimitRadarPoint(radarSpace);
                 CRadar::TransformRadarPointToScreenSpace(screenSpace, radarSpace);
 

--- a/src/CollectiblesOnRadar.cpp
+++ b/src/CollectiblesOnRadar.cpp
@@ -41,16 +41,33 @@ public:
             }
         };
 
+        // fires after the gang overlay, before the game's own blips - so the
+        // export icons end up underneath the player marker and the waypoint
+        plugin::Events::drawRadarOverlayEvent += []
+        {
+            CPlayerPed* playa = FindPlayerPed();
+            if (!s_modEnabled || !playa || !Settings::s_drawExportVehicles)
+            {
+                return;
+            }
+
+            ExportVehicles::update();
+
+            if (FrontEndMenuManager.m_bDrawRadarOrMap) // map
+            {
+                drawMapExports();
+            }
+            else if (playa->m_nAreaCode == 0) // radar
+            {
+                drawRadarExports(FindPlayerCentreOfWorld_NoSniperShift(0));
+            }
+        };
+
         plugin::Events::drawBlipsEvent += []
         {
             CPlayerPed* playa = FindPlayerPed();
             if (s_modEnabled && playa)
             {
-                if (Settings::s_drawExportVehicles)
-                {
-                    ExportVehicles::update();
-                }
-
                 const CVector& playaPos = FindPlayerCentreOfWorld_NoSniperShift(0);
                 if (!FrontEndMenuManager.m_bDrawRadarOrMap) // radar
                 {
@@ -59,7 +76,6 @@ public:
                         drawRadarTags(playaPos);
                         drawRadarPickups(playaPos); // oysters, horseshoes and snapshots
                         drawRadarUSJs(playaPos);
-                        drawRadarExports(playaPos);
                     }
                 }
                 else // map
@@ -68,7 +84,6 @@ public:
                     drawMapTags(playaPos, showHeight);
                     drawMapPickups(playaPos, showHeight); // oysters, horseshoes and snapshots
                     drawMapUSJs(playaPos, showHeight);
-                    drawMapExports();
                 }
             }
         };

--- a/src/CollectiblesOnRadar.cpp
+++ b/src/CollectiblesOnRadar.cpp
@@ -1,5 +1,6 @@
 #include "plugin.h"
 #include "common.h"
+#include "CCamera.h" // TheCamera
 #include "CHud.h" // CHud::SetHelpMessage
 #include "CMenuManager.h" // FrontEndMenuManager.drawRadarOrMap
 #include "CPickups.h"
@@ -581,6 +582,13 @@ private:
         if (ExportVehicles::isAtOwnSpawn(vehicle->m_nModelIndex, vehiclePos.x, vehiclePos.y))
         {
             return false; // spawn marker is already drawn there
+        }
+
+        // traffic behind the camera despawns quickly, so its icons only confuse
+        const CVector2D toVehicle((vehiclePos - TheCamera.GetPosition()).To2D());
+        if (TheCamera.GetForward().To2D().Dot(toVehicle) < 0.f)
+        {
+            return false;
         }
 
         return true;

--- a/src/CollectiblesOnRadar.cpp
+++ b/src/CollectiblesOnRadar.cpp
@@ -8,6 +8,7 @@
 
 #include "Util.h"
 #include "Settings.h"
+#include "ExportVehicles.h"
 
 class CollectiblesOnRadar
 {
@@ -45,6 +46,11 @@ public:
             CPlayerPed* playa = FindPlayerPed();
             if (s_modEnabled && playa)
             {
+                if (Settings::s_drawExportVehicles)
+                {
+                    ExportVehicles::update();
+                }
+
                 const CVector& playaPos = FindPlayerCentreOfWorld_NoSniperShift(0);
                 if (!FrontEndMenuManager.m_bDrawRadarOrMap) // radar
                 {
@@ -53,6 +59,7 @@ public:
                         drawRadarTags(playaPos);
                         drawRadarPickups(playaPos); // oysters, horseshoes and snapshots
                         drawRadarUSJs(playaPos);
+                        drawRadarExports(playaPos);
                     }
                 }
                 else // map
@@ -61,6 +68,7 @@ public:
                     drawMapTags(playaPos, showHeight);
                     drawMapPickups(playaPos, showHeight); // oysters, horseshoes and snapshots
                     drawMapUSJs(playaPos, showHeight);
+                    drawMapExports();
                 }
             }
         };
@@ -416,6 +424,150 @@ private:
         }
     }
 
+    static void drawExportIcon(float x, float y, bool onMap)
+    {
+        const float stretchX = RsGlobal.maximumWidth / 640.f;
+        const float stretchY = RsGlobal.maximumHeight / 448.f;
+
+        if (onMap) // map positions are in the menu's base space
+        {
+            x *= stretchX;
+            y *= stretchY;
+        }
+
+        const float halfW = Settings::s_exportSpriteSize * stretchX * 0.5f;
+        const float halfH = Settings::s_exportSpriteSize * stretchY * 0.5f;
+        CRadar::RadarBlipSprites[Settings::s_exportSpriteId].Draw(
+            CRect(x - halfW, y - halfH, x + halfW, y + halfH), CRGBA(255, 255, 255, 255));
+    }
+
+    static void drawRadarExports(const CVector& playaPos)
+    {
+        if (!Settings::s_drawExportVehicles)
+        {
+            return;
+        }
+
+        static CVector2D radarSpace, screenSpace;
+
+        CVehicle* playaVehicle = FindPlayerVehicle(-1, false);
+        const short playaModel = playaVehicle != nullptr ? playaVehicle->m_nModelIndex : -1;
+
+        bool modelIconDrawn[ExportVehicles::TOTAL_SPAWNS] = {};
+
+        for (int i = 0; i < ExportVehicles::TOTAL_SPAWNS; i++)
+        {
+            if (!ExportVehicles::s_wanted[i] || ExportVehicles::s_spawns[i].model == playaModel)
+            {
+                continue;
+            }
+
+            const CVehicle* tracked = ExportVehicles::s_vehicles[i];
+
+            const CVector2D worldPos = tracked != nullptr
+                ? tracked->GetPosition().To2D()
+                : CVector2D(ExportVehicles::s_spawns[i].x, ExportVehicles::s_spawns[i].y);
+
+            CRadar::TransformRealWorldPointToRadarSpace(radarSpace, worldPos);
+            if (CRadar::LimitRadarPoint(radarSpace) <= 1.f)
+            {
+                CRadar::TransformRadarPointToScreenSpace(screenSpace, radarSpace);
+                drawExportIcon(screenSpace.x, screenSpace.y, false);
+
+                if (tracked != nullptr)
+                {
+                    modelIconDrawn[i] = true;
+                }
+            }
+        }
+
+        // at most one icon per model - the icon sticks to its vehicle as long as
+        // it stays on the radar, then moves to the nearest matching one
+        CVehicle* nearestVehicle[ExportVehicles::TOTAL_SPAWNS] = {};
+        float nearestDistance[ExportVehicles::TOTAL_SPAWNS];
+        static int stickyVehicleRef[ExportVehicles::TOTAL_SPAWNS]; // 0 = none
+
+        for (int i = 0; i < CPools::ms_pVehiclePool->m_nSize; i++)
+        {
+            CVehicle* vehicle = CPools::ms_pVehiclePool->GetAt(i);
+            if (vehicle == nullptr || !isIconCandidate(vehicle, playaModel))
+            {
+                continue;
+            }
+
+            const int spawnIndex = ExportVehicles::wantedSpawnIndexForModel(vehicle->m_nModelIndex);
+            if (spawnIndex < 0 || modelIconDrawn[spawnIndex])
+            {
+                continue; // not wanted, or its tracked spawn car is already on the radar
+            }
+
+            const float distance = CVector2D::Distance(playaPos.To2D(), vehicle->GetPosition().To2D());
+            if (nearestVehicle[spawnIndex] == nullptr || distance < nearestDistance[spawnIndex])
+            {
+                nearestVehicle[spawnIndex] = vehicle;
+                nearestDistance[spawnIndex] = distance;
+            }
+        }
+
+        for (int i = 0; i < ExportVehicles::TOTAL_SPAWNS; i++)
+        {
+            CVehicle* sticky = stickyVehicleRef[i] != 0 ? CPools::ms_pVehiclePool->GetAtRef(stickyVehicleRef[i]) : nullptr;
+            if (sticky != nullptr
+                && (sticky->m_nModelIndex != ExportVehicles::s_spawns[i].model
+                    || !ExportVehicles::s_wanted[i] || modelIconDrawn[i]
+                    || !isIconCandidate(sticky, playaModel)))
+            {
+                sticky = nullptr;
+            }
+
+            stickyVehicleRef[i] = 0;
+
+            if (sticky != nullptr)
+            {
+                CRadar::TransformRealWorldPointToRadarSpace(radarSpace, sticky->GetPosition().To2D());
+                if (CRadar::LimitRadarPoint(radarSpace) <= 1.f)
+                {
+                    CRadar::TransformRadarPointToScreenSpace(screenSpace, radarSpace);
+                    drawExportIcon(screenSpace.x, screenSpace.y, false);
+                    stickyVehicleRef[i] = CPools::ms_pVehiclePool->GetRef(sticky);
+                    continue;
+                }
+            }
+
+            if (nearestVehicle[i] != nullptr)
+            {
+                CRadar::TransformRealWorldPointToRadarSpace(radarSpace, nearestVehicle[i]->GetPosition().To2D());
+                if (CRadar::LimitRadarPoint(radarSpace) <= 1.f)
+                {
+                    CRadar::TransformRadarPointToScreenSpace(screenSpace, radarSpace);
+                    drawExportIcon(screenSpace.x, screenSpace.y, false);
+                    stickyVehicleRef[i] = CPools::ms_pVehiclePool->GetRef(nearestVehicle[i]);
+                }
+            }
+        }
+    }
+
+    static bool isIconCandidate(CVehicle* vehicle, short playaModel)
+    {
+        if (vehicle->m_nModelIndex == playaModel || vehicle->m_fHealth <= 0.f || vehicle->m_nAreaCode != 0)
+        {
+            return false;
+        }
+
+        if (ExportVehicles::isTrackedVehicle(vehicle))
+        {
+            return false; // handled by the spawn loop
+        }
+
+        const CVector& vehiclePos = vehicle->GetPosition();
+        if (ExportVehicles::isAtOwnSpawn(vehicle->m_nModelIndex, vehiclePos.x, vehiclePos.y))
+        {
+            return false; // spawn marker is already drawn there
+        }
+
+        return true;
+    }
+
     ////////////////////////////////////////////////////////////////////////////////////////////////
 
     static void drawMapTags(const CVector& playaPos, bool showHeight)
@@ -563,6 +715,37 @@ private:
                 CRadar::ShowRadarTraceWithHeight(screenSpace.x, screenSpace.y, 1,
                     Settings::s_colorUSJ.r, Settings::s_colorUSJ.g, Settings::s_colorUSJ.b, Settings::s_colorUSJ.a, mode);
             }
+        }
+    }
+
+    static void drawMapExports()
+    {
+        if (!Settings::s_drawExportVehicles)
+        {
+            return;
+        }
+
+        static CVector2D radarSpace, screenSpace;
+
+        CVehicle* playaVehicle = FindPlayerVehicle(-1, false);
+        const short playaModel = playaVehicle != nullptr ? playaVehicle->m_nModelIndex : -1;
+
+        for (int i = 0; i < ExportVehicles::TOTAL_SPAWNS; i++)
+        {
+            if (!ExportVehicles::s_wanted[i] || ExportVehicles::s_spawns[i].model == playaModel)
+            {
+                continue;
+            }
+
+            const CVehicle* tracked = ExportVehicles::s_vehicles[i];
+
+            const CVector2D worldPos = tracked != nullptr
+                ? tracked->GetPosition().To2D()
+                : CVector2D(ExportVehicles::s_spawns[i].x, ExportVehicles::s_spawns[i].y);
+
+            CRadar::TransformRealWorldPointToRadarSpace(radarSpace, worldPos);
+            CRadar::TransformRadarPointToScreenSpace(screenSpace, radarSpace);
+            drawExportIcon(screenSpace.x, screenSpace.y, true);
         }
     }
 } collectiblesOnRadar;

--- a/src/ExportVehicles.cpp
+++ b/src/ExportVehicles.cpp
@@ -1,0 +1,126 @@
+#include "CPools.h" // CPools::ms_pVehiclePool
+#include "CVector.h"
+#include "CTheCarGenerators.h"
+
+#include "ExportVehicles.h"
+
+// Models and generator coordinates taken from the original main.scm source
+// (impexp_car_gen[30]); identical in every retail main.scm revision.
+const tExportSpawn ExportVehicles::s_spawns[ExportVehicles::TOTAL_SPAWNS] =
+{
+    // list 1
+    { 402, -1673.94f,   439.02f,  7.01f }, // Buffalo
+    { 405,   926.45f, -1292.29f, 13.60f }, // Sentinel
+    { 411, -2665.44f,   990.77f, 64.45f }, // Infernus
+    { 483, -2516.60f,  1228.92f, 36.43f }, // Camper
+    { 445,  1122.29f, -1699.76f, 13.43f }, // Admiral
+    { 470, -1006.41f,  -628.27f, 32.00f }, // Patriot
+    { 468, -2085.23f, -2437.52f, 30.31f }, // Sanchez
+    { 409, -1922.19f,   288.34f, 40.84f }, // Stretch
+    { 533,   -16.66f, -2521.17f, 36.37f }, // Feltzer
+    { 534,  1803.38f, -1931.05f, 13.66f }, // Remington
+
+    // list 2
+    { 415,  1272.24f,  2603.03f, 10.49f }, // Cheetah
+    { 489,  -112.40f,   -41.82f,  3.26f }, // Rancher
+    { 439, -2456.10f,   741.65f, 34.92f }, // Stallion
+    { 514, -1951.81f,  2393.83f, 50.08f }, // Tanker
+    { 480, -2751.79f,  -281.50f,  6.81f }, // Comet
+    { 535,  1923.93f, -2118.89f, 13.35f }, // Slamvan
+    { 496, -1675.94f,  -618.74f, 13.86f }, // Blista Compact
+    { 580, -2430.22f,   320.84f, 34.97f }, // Stafford
+    { 475, -2265.33f,   200.65f, 34.97f }, // Sabre
+    { 521,  2282.70f,  2535.88f, 10.39f }, // FCR-900
+
+    // list 3
+    { 429,  2133.04f,  1009.75f, 10.49f }, // Banshee
+    { 506,  2229.30f,  1402.99f, 10.82f }, // Super GT
+    { 508, -1550.40f,  2687.54f, 56.22f }, // Journey
+    { 579, -2068.69f,   -83.75f, 35.10f }, // Huntley
+    { 424,   682.17f, -1867.46f,  4.82f }, // BF Injection
+    { 536,  1747.87f, -2098.03f, 13.28f }, // Blade
+    { 463,  1144.46f, -1101.26f, 25.35f }, // Freeway
+    { 500, -2406.25f, -2180.84f, 33.39f }, // Mesa
+    { 477,  2163.79f,  1810.23f, 10.58f }, // ZR-350
+    { 587,  2207.43f,  1286.13f, 10.57f }, // Euros
+};
+
+bool ExportVehicles::s_wanted[ExportVehicles::TOTAL_SPAWNS];
+CVehicle* ExportVehicles::s_vehicles[ExportVehicles::TOTAL_SPAWNS];
+
+void ExportVehicles::update()
+{
+    for (int i = 0; i < TOTAL_SPAWNS; i++)
+    {
+        s_wanted[i] = false;
+        s_vehicles[i] = nullptr;
+    }
+
+    for (int i = 0; i < 500; i++) // static CCarGenerator CarGeneratorArray[500]
+    {
+        const CCarGenerator& gen = CTheCarGenerators::CarGeneratorArray[i];
+        if (!gen.m_bIsUsed || gen.m_nGenerateCount == 0)
+        {
+            continue;
+        }
+
+        for (int j = 0; j < TOTAL_SPAWNS; j++)
+        {
+            if (gen.m_nModelId != s_spawns[j].model)
+            {
+                continue;
+            }
+
+            const CVector genPos = gen.m_vecPosn.Uncompressed();
+            if (std::fabs(genPos.x - s_spawns[j].x) < 3.f && std::fabs(genPos.y - s_spawns[j].y) < 3.f)
+            {
+                s_wanted[j] = true;
+
+                // the car generated at this spawn, as long as it still exists
+                CVehicle* vehicle = CPools::ms_pVehiclePool->GetAtRef(gen.m_nVehicleHandle);
+                if (vehicle != nullptr && vehicle->m_fHealth > 0.f)
+                {
+                    s_vehicles[j] = vehicle;
+                }
+                break;
+            }
+        }
+    }
+}
+
+int ExportVehicles::wantedSpawnIndexForModel(short model)
+{
+    for (int i = 0; i < TOTAL_SPAWNS; i++)
+    {
+        if (s_wanted[i] && s_spawns[i].model == model)
+        {
+            return i;
+        }
+    }
+    return -1;
+}
+
+bool ExportVehicles::isTrackedVehicle(const CVehicle* vehicle)
+{
+    for (int i = 0; i < TOTAL_SPAWNS; i++)
+    {
+        if (s_wanted[i] && s_vehicles[i] == vehicle)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool ExportVehicles::isAtOwnSpawn(short model, float x, float y)
+{
+    for (int i = 0; i < TOTAL_SPAWNS; i++)
+    {
+        if (s_wanted[i] && s_spawns[i].model == model
+            && std::fabs(x - s_spawns[i].x) < 5.f && std::fabs(y - s_spawns[i].y) < 5.f)
+        {
+            return true;
+        }
+    }
+    return false;
+}

--- a/src/ExportVehicles.h
+++ b/src/ExportVehicles.h
@@ -1,0 +1,25 @@
+#pragma once
+
+class CVehicle;
+
+struct tExportSpawn
+{
+    short model;
+    float x, y, z;
+};
+
+class ExportVehicles
+{
+public:
+    static const int TOTAL_SPAWNS = 30;
+    static const tExportSpawn s_spawns[TOTAL_SPAWNS];
+
+    // refreshed by update() every frame
+    static bool s_wanted[TOTAL_SPAWNS];
+    static CVehicle* s_vehicles[TOTAL_SPAWNS]; // car spawned by the generator, if it still exists
+
+    static void update();
+    static int wantedSpawnIndexForModel(short model); // -1 if the model is not currently wanted
+    static bool isAtOwnSpawn(short model, float x, float y);
+    static bool isTrackedVehicle(const CVehicle* vehicle);
+};

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -5,6 +5,7 @@
 const std::string Settings::MAIN("MAIN");
 const std::string Settings::COLORS("COLORS");
 const std::string Settings::EXTRA("EXTRA");
+const std::string Settings::EXPORTS("EXPORT");
 
 // Default values
 
@@ -46,6 +47,12 @@ CRGBA Settings::s_colorWeapon(Settings::COLOR_DEFAULT);
 bool Settings::s_enabledOnStartup = true;
 bool Settings::s_drawDroppedWeapons = false;
 
+// [EXPORT]
+
+bool Settings::s_drawExportVehicles = false;
+unsigned short Settings::s_exportSpriteId = 55; // RADAR_SPRITE_IMPOUND
+int Settings::s_exportSpriteSize = 12;
+
 void Settings::read() {
     CIniReader iniReader("");
 
@@ -81,6 +88,16 @@ void Settings::read() {
 
     s_enabledOnStartup = iniReader.ReadBoolean(EXTRA, "enabled_on_startup", true);
     s_drawDroppedWeapons = iniReader.ReadBoolean(EXTRA, "draw_dropped_weapons", false);
+
+    // [EXPORT]
+
+    s_drawExportVehicles = iniReader.ReadBoolean(EXPORTS, "show_export_vehicles", false);
+
+    const int spriteId = iniReader.ReadInteger(EXPORTS, "sprite_id", 55);
+    s_exportSpriteId = (spriteId > 0 && spriteId < 63) ? static_cast<unsigned short>(spriteId) : 55;
+
+    const int spriteSize = iniReader.ReadInteger(EXPORTS, "sprite_size", 12);
+    s_exportSpriteSize = (spriteSize >= 4 && spriteSize <= 64) ? spriteSize : 12;
 }
 
 unsigned int Settings::toRGBA(const std::string& str, unsigned int defaultValue)

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -52,6 +52,7 @@ bool Settings::s_drawDroppedWeapons = false;
 bool Settings::s_drawExportVehicles = false;
 unsigned short Settings::s_exportSpriteId = 55; // RADAR_SPRITE_IMPOUND
 int Settings::s_exportSpriteSize = 12;
+bool Settings::s_drawExportArrows = true;
 
 void Settings::read() {
     CIniReader iniReader("");
@@ -98,6 +99,8 @@ void Settings::read() {
 
     const int spriteSize = iniReader.ReadInteger(EXPORTS, "sprite_size", 12);
     s_exportSpriteSize = (spriteSize >= 4 && spriteSize <= 64) ? spriteSize : 12;
+
+    s_drawExportArrows = iniReader.ReadBoolean(EXPORTS, "show_arrows", true);
 }
 
 unsigned int Settings::toRGBA(const std::string& str, unsigned int defaultValue)

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -55,6 +55,7 @@ public:
     static bool s_drawExportVehicles;
     static unsigned short s_exportSpriteId;
     static int s_exportSpriteSize;
+    static bool s_drawExportArrows;
 
 public:
     static void read();

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -8,6 +8,7 @@ public:
     static const std::string MAIN;
     static const std::string COLORS;
     static const std::string EXTRA;
+    static const std::string EXPORTS;
 
     // Default values
 
@@ -48,6 +49,12 @@ public:
     static CRGBA s_colorWeapon;
     static bool s_enabledOnStartup;
     static bool s_drawDroppedWeapons;
+
+    // [EXPORT]
+
+    static bool s_drawExportVehicles;
+    static unsigned short s_exportSpriteId;
+    static int s_exportSpriteSize;
 
 public:
     static void read();


### PR DESCRIPTION
Hello! I prepared two things in this PR - a compilation fix and a new feature.

## Fix: compilation with the latest plugin-sdk
The current plugin-sdk revision removed some APIs the project relied on:
- `DistanceBetweenPoints()` no longer exists - replaced with `CVector2D::Distance()`
- the `CVector2D(const CVector&)` constructor is gone - replaced with `CVector::To2D()`

Without these changes the project doesn't build against the up-to-date SDK.

## Feature: Import/Export wanted vehicles on the radar and map
After the Customs Fast Track mission the game asks you to deliver 30 vehicles
to the Easter Basin docks. This PR shows them like other collectibles:

- **Map**: an icon at the spawn location of every vehicle still required by
  the currently active list (already delivered cars and inactive lists don't
  show anything). Once the car has spawned, the icon follows the actual
  vehicle - so if you leave it somewhere, you can find it again.

- **Radar**: icons for matching vehicles around the player (including traffic),
  with at most one icon per model - the icon sticks to its vehicle while it's
  on the radar to avoid flickering between identical cars. All icons of a
  model are hidden while you're already driving that model.

No main.scm globals are read. The script keeps one dedicated car generator per
wanted vehicle (`impexp_car_gen[30]`) and switches it on only while the car is
needed, so the whole state can be read back from `CTheCarGenerators` by
matching model + position. The 30 entries are hardcoded from the original
script source, identical in every retail `main.scm`.

Everything is configurable via a new `[EXPORT]` INI section:
`show_export_vehicles`, `sprite_id` (default 55, the impound car icon) and
`sprite_size` (the icons are drawn with proper position stretching on the
frontend map).

Tested on 1.0 US.